### PR TITLE
hack: POC for a minimal version of the registry-control assertion

### DIFF
--- a/asserts/asserts.go
+++ b/asserts/asserts.go
@@ -153,6 +153,7 @@ var (
 	DeviceSessionRequestType = &AssertionType{"device-session-request", []string{"brand-id", "model", "serial"}, nil, assembleDeviceSessionRequest, noAuthority}
 	SerialRequestType        = &AssertionType{"serial-request", nil, nil, assembleSerialRequest, noAuthority}
 	AccountKeyRequestType    = &AssertionType{"account-key-request", []string{"public-key-sha3-384"}, nil, assembleAccountKeyRequest, noAuthority}
+	RegistryControlType      = &AssertionType{"registry-control", []string{"operator-id"}, nil, assembleRegistryControl, noAuthority}
 )
 
 var typeRegistry = map[string]*AssertionType{
@@ -178,6 +179,7 @@ var typeRegistry = map[string]*AssertionType{
 	DeviceSessionRequestType.Name: DeviceSessionRequestType,
 	SerialRequestType.Name:        SerialRequestType,
 	AccountKeyRequestType.Name:    AccountKeyRequestType,
+	RegistryControlType.Name:      RegistryControlType,
 }
 
 // Type returns the AssertionType with name or nil

--- a/asserts/batch.go
+++ b/asserts/batch.go
@@ -200,6 +200,17 @@ func (b *Batch) prereqSort(db *Database) error {
 		return nil
 	}
 
+	if b.added[0].Type() == RegistryControlType {
+		// TODO: find reasonable way to do these checks
+		// we need to check that a matching serial assertion exists
+		// & the serial's device-key-sha3-384 should match this
+		// assertion's sign-key-sha3-384
+
+		// for now, skip pre-req checks for this assertion type
+		b.inPrereqOrder = true
+		return nil
+	}
+
 	// put in prereq order using a fetcher
 	ordered := make([]Assertion, 0, len(b.added))
 	retrieve := func(ref *Ref) (Assertion, error) {

--- a/asserts/registry_control.go
+++ b/asserts/registry_control.go
@@ -1,0 +1,39 @@
+package asserts
+
+import (
+	"github.com/snapcore/snapd/registry"
+)
+
+// TODO: Add comments to all exported names
+
+type RegistryControl struct {
+	assertionBase
+	registryControl *registry.RegistryControl
+}
+
+// signKey returns the underlying public key of
+// the requested registry-control assertion
+func (rgctrl *RegistryControl) signKey() PublicKey {
+	// TODO
+	// it's hard to do this at this layer since
+	// we don't have access to the assertions datababse
+	return nil
+}
+
+func assembleRegistryControl(assert assertionBase) (Assertion, error) {
+	operatorID := assert.HeaderString("operator-id")
+
+	// TODO: check views exist
+	// basically do all the necessary validations
+	views := assert.Header("views")
+
+	registryControl, err := registry.NewRegistryControl(operatorID, views.([]interface{}))
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegistryControl{
+		assertionBase:   assert,
+		registryControl: registryControl,
+	}, nil
+}

--- a/cmd/snap/cmd_sign.go
+++ b/cmd/snap/cmd_sign.go
@@ -40,12 +40,14 @@ of the assertion can be specified through a "body" pseudo-header.
 `)
 
 type cmdSign struct {
+	clientMixin
 	Positional struct {
 		Filename flags.Filename
 	} `positional-args:"yes"`
 
-	KeyName keyName `short:"k" default:"default"`
-	Chain   bool    `long:"chain"`
+	KeyName   keyName `short:"k" default:"default"`
+	Chain     bool    `long:"chain"`
+	DeviceKey bool    `long:"device-key"`
 }
 
 func init() {
@@ -55,7 +57,8 @@ func init() {
 		// TRANSLATORS: This should not start with a lowercase letter.
 		"k": i18n.G("Name of the key to use, otherwise use the default key"),
 		// TRANSLATORS: This should not start with a lowercase letter.
-		"chain": i18n.G("Append the account and account-key assertions necessary to allow any device to validate the signed assertion."),
+		"chain":      i18n.G("Append the account and account-key assertions necessary to allow any device to validate the signed assertion."),
+		"device-key": i18n.G("Sign with the device-key"),
 	}, []argDesc{{
 		// TRANSLATORS: This needs to begin with < and end with >
 		name: i18n.G("<filename>"),
@@ -86,6 +89,14 @@ func (x *cmdSign) Execute(args []string) error {
 		return fmt.Errorf(i18n.G("cannot read assertion input: %v"), err)
 	}
 
+	if !x.DeviceKey {
+		return x.execOld(statement)
+	} else {
+		return x.execDevKey(statement)
+	}
+}
+
+func (x *cmdSign) execOld(statement []byte) error {
 	keypairMgr, err := signtool.GetKeypairManager()
 	if err != nil {
 		return err
@@ -163,4 +174,9 @@ func mustGetOneAssert(assertType string, headers map[string]string) (asserts.Ass
 	}
 
 	return asserts[0], nil
+}
+
+func (x *cmdSign) execDevKey(statement []byte) error {
+	// TODO!!!
+	return nil
 }

--- a/daemon/api.go
+++ b/daemon/api.go
@@ -89,6 +89,7 @@ var api = []*Command{
 	requestsPromptCmd,
 	requestsRulesCmd,
 	requestsRuleCmd,
+	signCmd,
 }
 
 const (

--- a/daemon/api_sign.go
+++ b/daemon/api_sign.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/signtool"
+	"github.com/snapcore/snapd/features"
+	"github.com/snapcore/snapd/overlord/auth"
+	"github.com/snapcore/snapd/overlord/configstate/config"
+	"github.com/snapcore/snapd/overlord/state"
+)
+
+var (
+	signCmd = &Command{
+		Path:        "/v2/sign",
+		POST:        doSign,
+		WriteAccess: authenticatedAccess{},
+	}
+)
+
+func doSign(c *Command, r *http.Request, user *auth.UserState) Response {
+	state := c.d.overlord.State()
+	state.Lock()
+	defer state.Unlock()
+
+	if err := validateRegistryControlFeatureFlag(state); err != nil {
+		return BadRequest("%v", err)
+	}
+
+	body, err := io.ReadAll(r.Body)
+
+	if err != nil {
+		return BadRequest("cannot read request body: %v", err)
+	}
+
+	deviceMgr := c.d.overlord.DeviceManager()
+
+	devKeyID, _ := deviceMgr.KeyID()
+	keypairMgr, _ := deviceMgr.KeyMgr()
+
+	signOpts := signtool.Options{
+		KeyID:     devKeyID,
+		Statement: body,
+	}
+
+	encodedAssert, err := signtool.Sign(&signOpts, keypairMgr)
+	if err != nil {
+		return BadRequest("cannot sign assertion: %v", err)
+	}
+
+	outBuf := bytes.NewBuffer(nil)
+	enc := asserts.NewEncoder(outBuf)
+
+	err = enc.WriteEncoded(encodedAssert)
+	if err != nil {
+		return BadRequest("cannot sign assertion: %v", err)
+	}
+
+	return SyncResponse(outBuf.String())
+}
+
+func validateRegistryControlFeatureFlag(st *state.State) *apiError {
+	tr := config.NewTransaction(st)
+	enabled, err := features.Flag(tr, features.RegistryControl)
+	if err != nil && !config.IsNoOption(err) {
+		return InternalError(fmt.Sprintf("internal error: cannot check registry-control feature flag: %s", err))
+	}
+
+	if !enabled {
+		_, confName := features.RegistryControl.ConfigOption()
+		return BadRequest(fmt.Sprintf(`"registry-control" feature flag is disabled: set '%s' to true`, confName))
+	}
+	return nil
+}

--- a/features/features.go
+++ b/features/features.go
@@ -77,6 +77,8 @@ const (
 	Registries
 	// AppArmorPrompting enables AppArmor to prompt the user for permission when apps perform certain operations.
 	AppArmorPrompting
+	// RegistryControl enables experimental remote management of registries
+	RegistryControl
 
 	// lastFeature is the final known feature, it is only used for testing.
 	lastFeature
@@ -119,7 +121,9 @@ var featureNames = map[SnapdFeature]string{
 	QuotaGroups: "quota-groups",
 
 	RefreshAppAwarenessUX: "refresh-app-awareness-ux",
-	Registries:            "registries",
+
+	Registries:      "registries",
+	RegistryControl: "registry-control",
 
 	AppArmorPrompting: "apparmor-prompting",
 }

--- a/overlord/devicestate/devicemgr.go
+++ b/overlord/devicestate/devicemgr.go
@@ -1963,6 +1963,34 @@ func (m *DeviceManager) keyPair() (asserts.PrivateKey, error) {
 	return privKey, nil
 }
 
+// BREAKING ALL THE ABSTRACTIONS!!
+func (m *DeviceManager) KeyMgr() (asserts.KeypairManager, error) {
+	device, err := m.device()
+	if err != nil {
+		return nil, err
+	}
+
+	if device.KeyID == "" {
+		return nil, state.ErrNoState
+	}
+
+	var keypairMgr asserts.KeypairManager
+	err = m.withKeypairMgr(func(mgr asserts.KeypairManager) (err error) {
+		keypairMgr = mgr
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return keypairMgr, nil
+}
+
+// BREAKING ALL THE ABSTRACTIONS!!
+func (m *DeviceManager) KeyID() (string, error) {
+	device, err := m.device()
+	return device.KeyID, err
+}
+
 // Registered returns a channel that is closed when the device is known to have been registered.
 func (m *DeviceManager) Registered() <-chan struct{} {
 	return m.reg

--- a/registry-control poc.md
+++ b/registry-control poc.md
@@ -1,0 +1,231 @@
+# registry-control poc
+
+This is a proof-of-concept that we can sign & acknowledge registry-control
+assertions as I learn the _snapd_ codebase.\
+Just in case you check the `diff` and wince (`git diff master..registry-control-assertion`),
+this is throwaway & hacked-together code. We'll do everything correctly soonest :).
+
+## Build & install the snap
+
+Pull the `registry-control-assertion` branch of this fork and then build the snap:
+
+```console
+$ snapcraft
+Installed package repositories
+Generated snap metadata
+Created snap package snapd_2.64+git175.gd32a5ae-dirty_amd64.snap
+
+$ sudo snap install snapd_2.64+git175.gd32a5ae-dirty_amd64.snap --dangerous
+2024-08-29T11:05:46+03:00 INFO Waiting for automatic snapd restart...
+snapd 2.64+git175.gd32a5ae-dirty installed
+```
+
+## Create the assertion
+
+Create a JSON assertion named `registry-control.json` with the following content:
+
+```json
+{
+    "type": "registry-control",
+    "operator-id": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN",
+    "views": [
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device"
+        },
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device"
+        },
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces"
+        },
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces"
+        }
+    ]
+}
+```
+
+## Sign the assertion
+
+First, we have to enable the `registry` & `registry-control` feature flags. \
+If we try signing right now, we'll get an error:
+
+```console
+$ sudo snap get system experimental -d
+{
+        "experimental": {
+                "registries": true,
+                "registry-control": false
+        }
+}
+
+$ sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/sign \
+    -X POST --data "$(cat registry-control.json)" | jq .result
+{
+  "message": "\"registry-control\" feature flag is disabled: set 'experimental.registry-control' to true (api)"
+}
+
+$ sudo snap set system experimental.registry-control=true
+```
+
+Next, sign the assertion using the API:
+
+```console
+$ sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/sign \
+    -X POST --data "$(cat registry-control.json)" | jq .result | \
+    awk '{gsub(/\\n/,"\n")}1' | awk '{gsub(/"/,"")}1' > registry-control.assert
+```
+
+The `registry-control.assert` assertion should look like:
+
+```yaml
+type: registry-control
+operator-id: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN
+views:
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces
+sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp
+
+AcLBUgQAAQoABgUCZtF51gAAbo0QAEsurlwSNIsSW3MMd+GI79fqXvGbhnBE3bt/EJeuJeXmyk8l
+lKOQZ3ZQygz5w3ZDeLVlEamjSxmvoJzbUtpLGtCwDGrro2vT4EAICvxVg21+ynsf1ulHO1GoS6Ge
+98qqOVtsrFc/ncDiNJuYr4BqCzlFxeLHJnchVcVHBHb07ND9jwzZJExxMIvUW+EJsxpL2ni8N6nD
+3ZKIcSQvFCaZTePmalY+AFZ0hTY8SvB0LE9DGhVbg4GtgBDZSXNO3u9clgGA3w5mTJm0spo/+9BU
+GgWAz2BvA5L/RP9vxbG2Y8q44yj7fJ2tzF4g2Dj5IOkPR5b2rQHY/lWKpai3mEjJ+6ZyMEVdDMIa
+O34fBB+subgADX2JdXot1vvC0U4GCbg5ShoZ2P+ynzde2PKAyxk94+457Jnw5A5BxTyH5wGlCqks
+D5jzHRrypR4zaVXQhEcf6g3DsCSgLhAyqO+e51Nz/2SElyRiKGjVlGKNZKBMbGrC6vqAJxiX1vCl
+/dcWAlmplJGIZWLrgzM0MZObnr7vReYUc/1Xb+ksXllVWcKwEfWIDhi5LDp2Ez2QquTy0yhozRkm
+84AuLYG4nlt/EMkxOHbGHFSCZxKD39Ws31UkBTlxmruCkdI4wna+d+z0J5esGmXuhrG4OQlS/Vlt
+xPhuNdKk1wnNwl5THvD1fFwCI7/R
+```
+
+We can double check that the assertion's signing key (`sign-key-sha3-384`) is
+the same as the device-key (`device-key-sha3-384`):
+
+```console
+$ snap known serial
+[...]
+device-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp
+timestamp: 2024-08-29T13:42:13.874988Z
+sign-key-sha3-384: wrfougkz3Huq2T_KklfnufCC0HzG7bJ9wP99GV0FF-D3QH3eJtuSRlQc2JhrAoh1
+[...]
+```
+
+// TODO
+
+Alternatively, you can sign the assertion with the CLI:
+
+```console
+$ snap sign ...
+```
+
+## Acknowledge the assertion
+
+```console
+$ snap ack registry-control.assert
+```
+
+## Fetch the assertion
+
+### `registry-control` is a known assertion type
+
+```console
+$ curl -s --unix-socket /run/snapd.socket http://localhost/v2/assertions -X GET | jq .result
+{
+  "types": [
+    "account",
+    "account-key",
+    "account-key-request",
+    "base-declaration",
+    "device-session-request",
+    "model",
+    "preseed",
+    "registry",
+    "registry-control",
+    "repair",
+    "serial",
+    "serial-request",
+    "snap-build",
+    "snap-declaration",
+    "snap-developer",
+    "snap-resource-pair",
+    "snap-resource-revision",
+    "snap-revision",
+    "store",
+    "system-user",
+    "validation",
+    "validation-set"
+  ]
+}
+```
+
+### GET with API
+
+```console
+$ curl -s --unix-socket /run/snapd.socket http://localhost/v2/assertions/registry-control -X GET
+type: registry-control
+operator-id: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN
+views:
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces
+sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp
+
+AcLBUgQAAQoABgUCZtF51gAAbo0QAEsurlwSNIsSW3MMd+GI79fqXvGbhnBE3bt/EJeuJeXmyk8l
+lKOQZ3ZQygz5w3ZDeLVlEamjSxmvoJzbUtpLGtCwDGrro2vT4EAICvxVg21+ynsf1ulHO1GoS6Ge
+98qqOVtsrFc/ncDiNJuYr4BqCzlFxeLHJnchVcVHBHb07ND9jwzZJExxMIvUW+EJsxpL2ni8N6nD
+3ZKIcSQvFCaZTePmalY+AFZ0hTY8SvB0LE9DGhVbg4GtgBDZSXNO3u9clgGA3w5mTJm0spo/+9BU
+GgWAz2BvA5L/RP9vxbG2Y8q44yj7fJ2tzF4g2Dj5IOkPR5b2rQHY/lWKpai3mEjJ+6ZyMEVdDMIa
+O34fBB+subgADX2JdXot1vvC0U4GCbg5ShoZ2P+ynzde2PKAyxk94+457Jnw5A5BxTyH5wGlCqks
+D5jzHRrypR4zaVXQhEcf6g3DsCSgLhAyqO+e51Nz/2SElyRiKGjVlGKNZKBMbGrC6vqAJxiX1vCl
+/dcWAlmplJGIZWLrgzM0MZObnr7vReYUc/1Xb+ksXllVWcKwEfWIDhi5LDp2Ez2QquTy0yhozRkm
+84AuLYG4nlt/EMkxOHbGHFSCZxKD39Ws31UkBTlxmruCkdI4wna+d+z0J5esGmXuhrG4OQlS/Vlt
+xPhuNdKk1wnNwl5THvD1fFwCI7/R
+```
+
+### GET with CLI
+
+```console
+$ snap known registry-control
+type: registry-control
+operator-id: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN
+views:
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces
+sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp
+
+AcLBUgQAAQoABgUCZtF51gAAbo0QAEsurlwSNIsSW3MMd+GI79fqXvGbhnBE3bt/EJeuJeXmyk8l
+lKOQZ3ZQygz5w3ZDeLVlEamjSxmvoJzbUtpLGtCwDGrro2vT4EAICvxVg21+ynsf1ulHO1GoS6Ge
+98qqOVtsrFc/ncDiNJuYr4BqCzlFxeLHJnchVcVHBHb07ND9jwzZJExxMIvUW+EJsxpL2ni8N6nD
+3ZKIcSQvFCaZTePmalY+AFZ0hTY8SvB0LE9DGhVbg4GtgBDZSXNO3u9clgGA3w5mTJm0spo/+9BU
+GgWAz2BvA5L/RP9vxbG2Y8q44yj7fJ2tzF4g2Dj5IOkPR5b2rQHY/lWKpai3mEjJ+6ZyMEVdDMIa
+O34fBB+subgADX2JdXot1vvC0U4GCbg5ShoZ2P+ynzde2PKAyxk94+457Jnw5A5BxTyH5wGlCqks
+D5jzHRrypR4zaVXQhEcf6g3DsCSgLhAyqO+e51Nz/2SElyRiKGjVlGKNZKBMbGrC6vqAJxiX1vCl
+/dcWAlmplJGIZWLrgzM0MZObnr7vReYUc/1Xb+ksXllVWcKwEfWIDhi5LDp2Ez2QquTy0yhozRkm
+84AuLYG4nlt/EMkxOHbGHFSCZxKD39Ws31UkBTlxmruCkdI4wna+d+z0J5esGmXuhrG4OQlS/Vlt
+xPhuNdKk1wnNwl5THvD1fFwCI7/R
+```
+
+## Clean-up
+
+Roll back to the correct `snapd` version:
+
+```console
+$ snap refresh snapd --stable --amend
+```

--- a/registry-control.assert
+++ b/registry-control.assert
@@ -1,0 +1,24 @@
+type: registry-control
+operator-id: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN
+views:
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces
+  -
+    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces
+sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp
+
+AcLBUgQAAQoABgUCZtGLSQAA3tgQAF4HodEkxg9z3tkHYQDd5pirnVQKMXnDLgUl0HYCYxb7S42A
+ufn+kzEqmA3n5skcP3/Kp7RLUg5FLM8StP3MxuLdN1RmtrSe8vMSeRl5pu4Fv2Rb+wubBoydFHmg
+pHQzQl87K83HKzoAlwyaflq9nlRR2XoAJU2GhVQ/iiQNKIX4E1GvE51iE2kc4xfIc0g3xHLGG0ou
+une8w9TZdbJ7QRF1k/iL2a8iO6L+YpI7LdNorJ05UE0wNkY2B639bLBaK/vt6veVqd02BqjgNO0o
+F6sR/PfhBpPrXj3ue8SEJg6QYar1gMBjOf0ooWHMAATJ/kCaCsQIUMX4KxL9Kp+zV+YBudjVjfrx
+zGNpBn6mMTCpzFpwsVXWCNzObyWQs8h48XE8/fdCDojizK6U2u2br8BT1TixNWn45MOeu53EsPYR
+xGOFp5oxPoq/VBzHPgC8Ifs5WPlVWfMR9Z9LGjT9B5QF55PNpHMqFzHL3WilpqMeAcLrrpTEBuva
+SNpiV1oWr5ASAlwuZNM56d6XZsx6JnmUThF8II5ShEKVq3C8wjgjfiGvv/FDd7BrwakWOBYZ+rTS
+5hcCjevlvryNvk1VXXDHmnUd+cAxJzxczImPy3sWPmQ6CHCYfBokY/DcgCycQFNWLnpxRkeaaJ0s
+6iJ/JaYPWE2SILtuzgr7w5Dyf00I
+

--- a/registry-control.json
+++ b/registry-control.json
@@ -1,0 +1,18 @@
+{
+    "type": "registry-control",
+    "operator-id": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN",
+    "views": [
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device"
+        },
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device"
+        },
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces"
+        },
+        {
+            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces"
+        }
+    ]
+}

--- a/registry/registry_control.go
+++ b/registry/registry_control.go
@@ -1,0 +1,36 @@
+package registry
+
+// TODO: Add comments to all exported names
+
+type RegistryControl struct {
+	OperatorID string
+	views      []DelegatedView
+}
+
+type DelegatedView struct {
+	Name string
+}
+
+func NewRegistryControl(operatorID string, views []interface{}) (*RegistryControl, error) {
+	registryControl := &RegistryControl{
+		OperatorID: operatorID,
+		views:      make([]DelegatedView, len(views)),
+	}
+
+	for _, view := range views {
+		// TODO: handle/propagate err
+		delegatedView, _ := newDelegatedView(view.(map[string]interface{}))
+
+		registryControl.views = append(registryControl.views, *delegatedView)
+	}
+
+	return registryControl, nil
+}
+
+func newDelegatedView(view map[string]interface{}) (*DelegatedView, error) {
+	// TODO: validate "name" exists
+	// TODO: validate the path pattern
+	// 	& that the registry exists
+	//		cache the checks?
+	return &DelegatedView{Name: view["name"].(string)}, nil
+}


### PR DESCRIPTION
This is a proof-of-concept that we can sign & acknowledge registry-control
assertions as I learn the _snapd_ codebase.\
Just in case you check the `diff` and wince (`git diff master..registry-control-assertion`),
this is throwaway & hacked-together code. We'll do everything correctly soonest :).

## Build & install the snap

Pull the `registry-control-assertion` branch of this fork and then build the snap:

```console
$ snapcraft
Installed package repositories
Generated snap metadata
Created snap package snapd_2.64+git175.gd32a5ae-dirty_amd64.snap

$ sudo snap install snapd_2.64+git175.gd32a5ae-dirty_amd64.snap --dangerous
2024-08-29T11:05:46+03:00 INFO Waiting for automatic snapd restart...
snapd 2.64+git175.gd32a5ae-dirty installed
```

## Create the assertion

Create a JSON assertion named `registry-control.json` with the following content:

```json
{
    "type": "registry-control",
    "operator-id": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN",
    "views": [
        {
            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device"
        },
        {
            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device"
        },
        {
            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces"
        },
        {
            "name": "f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces"
        }
    ]
}
```

## Sign the assertion

First, we have to enable the `registry` & `registry-control` feature flags. \
If we try signing right now, we'll get an error:

```console
$ sudo snap get system experimental -d
{
        "experimental": {
                "registries": true,
                "registry-control": false
        }
}

$ sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/sign \
    -X POST --data "$(cat registry-control.json)" | jq .result
{
  "message": "\"registry-control\" feature flag is disabled: set 'experimental.registry-control' to true (api)"
}

$ sudo snap set system experimental.registry-control=true
```

Next, sign the assertion using the API:

```console
$ sudo curl -s --unix-socket /run/snapd.socket http://localhost/v2/sign \
    -X POST --data "$(cat registry-control.json)" | jq .result | \
    awk '{gsub(/\\n/,"\n")}1' | awk '{gsub(/"/,"")}1' > registry-control.assert
```

The `registry-control.assert` assertion should look like:

```yaml
type: registry-control
operator-id: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN
views:
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces
sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp

AcLBUgQAAQoABgUCZtF51gAAbo0QAEsurlwSNIsSW3MMd+GI79fqXvGbhnBE3bt/EJeuJeXmyk8l
lKOQZ3ZQygz5w3ZDeLVlEamjSxmvoJzbUtpLGtCwDGrro2vT4EAICvxVg21+ynsf1ulHO1GoS6Ge
98qqOVtsrFc/ncDiNJuYr4BqCzlFxeLHJnchVcVHBHb07ND9jwzZJExxMIvUW+EJsxpL2ni8N6nD
3ZKIcSQvFCaZTePmalY+AFZ0hTY8SvB0LE9DGhVbg4GtgBDZSXNO3u9clgGA3w5mTJm0spo/+9BU
GgWAz2BvA5L/RP9vxbG2Y8q44yj7fJ2tzF4g2Dj5IOkPR5b2rQHY/lWKpai3mEjJ+6ZyMEVdDMIa
O34fBB+subgADX2JdXot1vvC0U4GCbg5ShoZ2P+ynzde2PKAyxk94+457Jnw5A5BxTyH5wGlCqks
D5jzHRrypR4zaVXQhEcf6g3DsCSgLhAyqO+e51Nz/2SElyRiKGjVlGKNZKBMbGrC6vqAJxiX1vCl
/dcWAlmplJGIZWLrgzM0MZObnr7vReYUc/1Xb+ksXllVWcKwEfWIDhi5LDp2Ez2QquTy0yhozRkm
84AuLYG4nlt/EMkxOHbGHFSCZxKD39Ws31UkBTlxmruCkdI4wna+d+z0J5esGmXuhrG4OQlS/Vlt
xPhuNdKk1wnNwl5THvD1fFwCI7/R
```

We can double check that the assertion's signing key (`sign-key-sha3-384`) is
the same as the device-key (`device-key-sha3-384`):

```console
$ snap known serial
[...]
device-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp
timestamp: 2024-08-29T13:42:13.874988Z
sign-key-sha3-384: wrfougkz3Huq2T_KklfnufCC0HzG7bJ9wP99GV0FF-D3QH3eJtuSRlQc2JhrAoh1
[...]
```

// TODO

Alternatively, you can sign the assertion with the CLI:

```console
$ snap sign ...
```

## Acknowledge the assertion

```console
$ snap ack registry-control.assert
```

## Fetch the assertion

### `registry-control` is a known assertion type

```console
$ curl -s --unix-socket /run/snapd.socket http://localhost/v2/assertions -X GET | jq .result
{
  "types": [
    "account",
    "account-key",
    "account-key-request",
    "base-declaration",
    "device-session-request",
    "model",
    "preseed",
    "registry",
    "registry-control",
    "repair",
    "serial",
    "serial-request",
    "snap-build",
    "snap-declaration",
    "snap-developer",
    "snap-resource-pair",
    "snap-resource-revision",
    "snap-revision",
    "store",
    "system-user",
    "validation",
    "validation-set"
  ]
}
```

### GET with API

```console
$ curl -s --unix-socket /run/snapd.socket http://localhost/v2/assertions/registry-control -X GET
type: registry-control
operator-id: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN
views:
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces
sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp

AcLBUgQAAQoABgUCZtF51gAAbo0QAEsurlwSNIsSW3MMd+GI79fqXvGbhnBE3bt/EJeuJeXmyk8l
lKOQZ3ZQygz5w3ZDeLVlEamjSxmvoJzbUtpLGtCwDGrro2vT4EAICvxVg21+ynsf1ulHO1GoS6Ge
98qqOVtsrFc/ncDiNJuYr4BqCzlFxeLHJnchVcVHBHb07ND9jwzZJExxMIvUW+EJsxpL2ni8N6nD
3ZKIcSQvFCaZTePmalY+AFZ0hTY8SvB0LE9DGhVbg4GtgBDZSXNO3u9clgGA3w5mTJm0spo/+9BU
GgWAz2BvA5L/RP9vxbG2Y8q44yj7fJ2tzF4g2Dj5IOkPR5b2rQHY/lWKpai3mEjJ+6ZyMEVdDMIa
O34fBB+subgADX2JdXot1vvC0U4GCbg5ShoZ2P+ynzde2PKAyxk94+457Jnw5A5BxTyH5wGlCqks
D5jzHRrypR4zaVXQhEcf6g3DsCSgLhAyqO+e51Nz/2SElyRiKGjVlGKNZKBMbGrC6vqAJxiX1vCl
/dcWAlmplJGIZWLrgzM0MZObnr7vReYUc/1Xb+ksXllVWcKwEfWIDhi5LDp2Ez2QquTy0yhozRkm
84AuLYG4nlt/EMkxOHbGHFSCZxKD39Ws31UkBTlxmruCkdI4wna+d+z0J5esGmXuhrG4OQlS/Vlt
xPhuNdKk1wnNwl5THvD1fFwCI7/R
```

### GET with CLI

```console
$ snap known registry-control
type: registry-control
operator-id: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN
views:
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-device
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-device
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/control-interfaces
  -
    name: f22PSauKuNkwQTM9Wz67ZCjNACuSjjhN/network/observe-interfaces
sign-key-sha3-384: t9yuKGLyiezBq_PXMJZsGdkTukmL7MgrgqXAlxxiZF4TYryOjZcy48nnjDmEHQDp

AcLBUgQAAQoABgUCZtF51gAAbo0QAEsurlwSNIsSW3MMd+GI79fqXvGbhnBE3bt/EJeuJeXmyk8l
lKOQZ3ZQygz5w3ZDeLVlEamjSxmvoJzbUtpLGtCwDGrro2vT4EAICvxVg21+ynsf1ulHO1GoS6Ge
98qqOVtsrFc/ncDiNJuYr4BqCzlFxeLHJnchVcVHBHb07ND9jwzZJExxMIvUW+EJsxpL2ni8N6nD
3ZKIcSQvFCaZTePmalY+AFZ0hTY8SvB0LE9DGhVbg4GtgBDZSXNO3u9clgGA3w5mTJm0spo/+9BU
GgWAz2BvA5L/RP9vxbG2Y8q44yj7fJ2tzF4g2Dj5IOkPR5b2rQHY/lWKpai3mEjJ+6ZyMEVdDMIa
O34fBB+subgADX2JdXot1vvC0U4GCbg5ShoZ2P+ynzde2PKAyxk94+457Jnw5A5BxTyH5wGlCqks
D5jzHRrypR4zaVXQhEcf6g3DsCSgLhAyqO+e51Nz/2SElyRiKGjVlGKNZKBMbGrC6vqAJxiX1vCl
/dcWAlmplJGIZWLrgzM0MZObnr7vReYUc/1Xb+ksXllVWcKwEfWIDhi5LDp2Ez2QquTy0yhozRkm
84AuLYG4nlt/EMkxOHbGHFSCZxKD39Ws31UkBTlxmruCkdI4wna+d+z0J5esGmXuhrG4OQlS/Vlt
xPhuNdKk1wnNwl5THvD1fFwCI7/R
```

## Clean-up

Roll back to the correct `snapd` version:

```console
$ snap refresh snapd --stable --amend
```
